### PR TITLE
fix: 🐛 isFunction no longer available with Node >=23

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const { isString, isFunction } = require('util')
 const debug = require('./lib/debug')('Trie')
 const _DFS = Symbol('dfs')
 const _BFS = Symbol('bfs')
@@ -256,7 +255,8 @@ class Trie {
 	_isValidKey(key) {
 		// const rightType = Array.isArray(key) || isString(key)
 		// return rightType && key.length > 0
-		return isFunction(key[Symbol.iterator])
+
+		return typeof key[Symbol.iterator] === 'function'
 	}
 
 	_newTrieLikeThis(root, shallow = false) {


### PR DESCRIPTION
util.isFunction() is deprecated since Node 4.0. 

Checking the last available doc with isFunction in it, on https://nodejs.org/docs/latest-v22.x/api/util.html#utilisfunctionobject 

The documentation suggests using `typeof value === 'function'` instead.

✅ Closes: #8